### PR TITLE
Make sure memory-overriding tests run in separate process

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: true
+      run: cargo build
     - name: Run tests
-      run: true
+      run: cargo test

--- a/src/resource_limiter.rs
+++ b/src/resource_limiter.rs
@@ -54,6 +54,11 @@ pub(crate) struct ResourceLimiterImpl {
 pub struct ResourceLimiter(Rc<RefCell<ResourceLimiterImpl>>);
 
 impl ResourceLimiterImpl {
+    // WARNING: This function sets a global memory limit that affects the entire
+    // process. The memory limit is enforced by the global allocator and will
+    // cause allocation failures when exceeded. Use with caution in
+    // multi-threaded environments or when other parts of the process may
+    // allocate memory concurrently.
     pub fn new(time_limit_ms: u64, global_mem_limit_bytes: usize) -> Self {
         set_memory_limit(global_mem_limit_bytes);
         Self {

--- a/src/test/limits.rs
+++ b/src/test/limits.rs
@@ -1,5 +1,5 @@
 use crate::{FbasAnalyzer, FbasError, ResourceLimiter, SolveStatus};
-use std::{path::PathBuf, process::Command};
+use std::{path::PathBuf, process::Command, u64};
 
 fn assert_solver_limit_exceeded(res: Result<SolveStatus, FbasError>) -> bool {
     match res {
@@ -14,28 +14,48 @@ fn assert_solver_limit_exceeded(res: Result<SolveStatus, FbasError>) -> bool {
     }
 }
 
-fn wrapped_solve(
-    json_file: &PathBuf,
-    time_limit_ms: u64,
-    memory_limit_bytes: usize,
-) -> Result<SolveStatus, FbasError> {
+fn solve_unlimited(json_file: &PathBuf) -> Result<SolveStatus, FbasError> {
     let mut solver = FbasAnalyzer::from_json_path(
         json_file.as_os_str().to_str().unwrap(),
-        ResourceLimiter::new(time_limit_ms, memory_limit_bytes),
+        ResourceLimiter::unlimited(),
     )?;
     solver.solve()
 }
 
-// This is a helper test that will be run in its own process. It is expected to
-// fail with memory allocation error therefore we don't include it in the
-// regular test suite.
+fn solve_with_time_limit(
+    json_file: &PathBuf,
+    time_limit_ms: u64,
+) -> Result<SolveStatus, FbasError> {
+    let mut solver = FbasAnalyzer::from_json_path(
+        json_file.as_os_str().to_str().unwrap(),
+        ResourceLimiter::new(time_limit_ms, usize::MAX),
+    )?;
+    solver.solve()
+}
+
+// This is a test helper that overrides the global allocator's memory limit, and
+// therefore must be run in an isolated process. It is ignored when running the
+// regular test setup.
 #[ignore]
 #[test]
 fn test_memory_limit_ps() {
+    let args: Vec<String> = std::env::args().collect();
+    // args[]: program name, test name, "--include-ignored", "--no-capture", memory_limit_bytes
+    let memory_limit_bytes = if args.len() > 4 {
+        args[4].parse::<usize>().unwrap()
+    } else {
+        usize::MAX
+    };
+
     let json_file = std::path::PathBuf::from(
         "./tests/test_data/random/almost_symmetric_network_16_orgs_delete_prob_factor_3.json",
     );
-    let _ = wrapped_solve(&json_file, 1000, 100000);
+    let mut solver = FbasAnalyzer::from_json_path(
+        json_file.as_os_str().to_str().unwrap(),
+        ResourceLimiter::new(u64::MAX, memory_limit_bytes),
+    )
+    .unwrap();
+    solver.solve().unwrap();
 }
 
 #[test]
@@ -44,27 +64,29 @@ fn test_time_limit() -> Result<(), Box<dyn std::error::Error>> {
         "./tests/test_data/random/almost_symmetric_network_16_orgs_delete_prob_factor_3.json",
     );
     // first solve it without interruption, it should return `UNSAT`
-    assert_eq!(
-        wrapped_solve(&json_file, 1000, 100_000_000)?,
-        SolveStatus::UNSAT
-    );
+    assert_eq!(solve_unlimited(&json_file)?, SolveStatus::UNSAT);
 
     // reaching time limit, it should fail gracefully with an FbasError
-    assert_solver_limit_exceeded(wrapped_solve(&json_file, 1, 10000000));
+    assert_solver_limit_exceeded(solve_with_time_limit(&json_file, 1));
     Ok(())
 }
 
 #[test]
 fn test_memory_limit() -> Result<(), Box<dyn std::error::Error>> {
-    let json_file = PathBuf::from(
-        "./tests/test_data/random/almost_symmetric_network_16_orgs_delete_prob_factor_3.json",
-    );
-
-    // first solve it without interruption, it should return `UNSAT`
-    assert_eq!(
-        wrapped_solve(&json_file, 1000, 100_000_000)?,
-        SolveStatus::UNSAT
-    );
+    // first solve it without interruption, it should return normally
+    let output = Command::new("cargo")
+        .args([
+            "test",
+            "--package",
+            "stellar-quorum-analyzer",
+            "--lib",
+            "--",
+            "test_memory_limit_ps",
+            "--include-ignored",
+            "--nocapture",
+        ])
+        .output()?;
+    assert_eq!(output.status.code(), Some(0));
 
     // Test memory limit - should abort due to LimitedAllocator
     let output = Command::new("cargo")
@@ -77,6 +99,7 @@ fn test_memory_limit() -> Result<(), Box<dyn std::error::Error>> {
             "test_memory_limit_ps",
             "--include-ignored",
             "--nocapture",
+            "1000", // memory_limit_bytes
         ])
         .output()?;
 


### PR DESCRIPTION
Fix broken CI due to running tests concurrently while some tests lowers the global memory limit.