### PR TITLE
bump to actual 23.0.0 release not rc3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -568,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "23.0.0-rc.3"
+version = "23.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "466946ea96ee221ac75b2a479ef4aa1cbbb7bf0ac11154616d7fcd2f00324b8a"
+checksum = "89d2848e1694b0c8db81fd812bfab5ea71ee28073e09ccc45620ef3cf7a75a9b"
 dependencies = [
  "cfg_eval",
  "crate-git-revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 petgraph = "=0.6.5"
-stellar-xdr = "=23.0.0-rc.3"
+stellar-xdr = "=23.0.0"
 json = { version = "0.12.4", optional = true }
 itertools = "0.10.5"
 stellar-strkey = "0.0.13"


### PR DESCRIPTION
Because of the equality constraint here we will actually need this crate to evolve in lock step with the XDRs depended-on by core's (proposed elsewhere) unified build mode. I'm not sure if this is is ideal; we might be able to weaken the relationship slightly but for now I think this is our best bet.