### PR TITLE
bump xdr for bn254

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,8 +569,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "23.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d2848e1694b0c8db81fd812bfab5ea71ee28073e09ccc45620ef3cf7a75a9b"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=8505f22833f4054227689c35f9cf253a6836cbac#8505f22833f4054227689c35f9cf253a6836cbac"
 dependencies = [
  "cfg_eval",
  "crate-git-revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 petgraph = "=0.6.5"
-stellar-xdr = "=23.0.0"
+stellar-xdr = { version = "=23.0.0", git = "https://github.com/stellar/rs-stellar-xdr", rev = "8505f22833f4054227689c35f9cf253a6836cbac" }
 json = { version = "0.12.4", optional = true }
 itertools = "0.10.5"
 stellar-strkey = "0.0.13"


### PR DESCRIPTION
Required for the protocol bump because stellar-core does an xdr hash check. 