### PR TITLE
Add git rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,8 +569,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "24.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f251bec16969e6b305232f288d3f09c1ae4a90bcaeb541d43d9a801505bfca7"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=89cc1cbadf1b9a16843826954dede7fec514d8e7#89cc1cbadf1b9a16843826954dede7fec514d8e7"
 dependencies = [
  "cfg_eval",
  "crate-git-revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 petgraph = "=0.6.5"
-stellar-xdr = { version = "=24.0.1" }
+stellar-xdr = { version = "=24.0.1", git = "https://github.com/stellar/rs-stellar-xdr", rev = "89cc1cbadf1b9a16843826954dede7fec514d8e7" }
 json = { version = "0.12.4", optional = true }
 itertools = "0.10.5"
 stellar-strkey = "0.0.13"


### PR DESCRIPTION
Core requires the git rev to avoid a conflict with the xdr crate from the v24 env.