### PR TITLE
Bump xdr to p26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,8 +569,7 @@ dependencies = [
 [[package]]
 name = "stellar-xdr"
 version = "25.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d20dafed80076b227d4b17c0c508a4bbc4d5e4c3d4c1de7cd42242df4b1eaf"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=99c73b18ccd68bc3439be30801da6261b193d2da#99c73b18ccd68bc3439be30801da6261b193d2da"
 dependencies = [
  "cfg_eval",
  "crate-git-revision",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 petgraph = "=0.6.5"
-stellar-xdr = { version = "=25.0.0" }
+stellar-xdr = { version = "=25.0.0", git = "https://github.com/stellar/rs-stellar-xdr", rev = "99c73b18ccd68bc3439be30801da6261b193d2da" }
 json = { version = "0.12.4", optional = true }
 itertools = "0.10.5"
 stellar-strkey = "0.0.13"


### PR DESCRIPTION
Xdr hasn't been released yet, so we'll use the git rev for now.