### PR TITLE
Bump stellar-xdr to v27.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,9 +188,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "fixedbitset"
@@ -557,8 +557,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-xdr"
-version = "26.0.0"
-source = "git+https://github.com/stellar/rs-stellar-xdr?rev=f0ed902950d517ec3cc31d5af7c268e2f025d093#f0ed902950d517ec3cc31d5af7c268e2f025d093"
+version = "27.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
 dependencies = [
  "crate-git-revision",
  "escape-bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 petgraph = "=0.6.5"
-stellar-xdr = { version = "=26.0.0", git = "https://github.com/stellar/rs-stellar-xdr", rev = "f0ed902950d517ec3cc31d5af7c268e2f025d093" }
+stellar-xdr = "=27.0.0"
 json = { version = "0.12.4", optional = true }
 itertools = "0.10.5"
 stellar-strkey = "0.0.13"


### PR DESCRIPTION
Updates the `stellar-xdr` dependency to the [v27.0.0 release](https://github.com/stellar/rs-stellar-xdr/releases/tag/v27.0.0).

The dependency is pinned to rev `5262803470be965e42f80023d12fba12808c774a`, which is the commit the `v27.0.0` tag points to.

## Testing
- `cargo check --all-targets` passes.