### PR TITLE
Detect no-quorum FBAS and report `NoQuorum` instead of `UNSAT`

### DIFF
--- a/docs/method.md
+++ b/docs/method.md
@@ -121,3 +121,33 @@ Similarly for $B$:
 $$
 \bigwedge_{i=1}^M \left(\left(\neg B_i \vee \bigvee_{j=1}^{|\Pi_i|} \beta_i^j\right)\wedge \bigwedge_{j=1}^{|\Pi_i|}\left(\bigwedge_{k\in s_i^j} \left( \neg \beta_i^j \vee B_k \right) \right)  \wedge \left( \beta_i^j \vee \bigvee_{k\in s_i^j}\neg B_k \right)\right)
 $$
+
+## Quorum existence and the `NoQuorum` result
+
+The CNF above is satisfiable iff two non-empty, disjoint quorums exist. A plain
+`UNSAT` therefore answers "there are no two disjoint quorums" — but that single
+answer collapses two opposite network states:
+
+1. **Intertwined (healthy):** quorums exist and every pair of quorums
+   intersects.
+2. **Degenerate:** no quorum exists at all (for example, a validator's threshold
+   cannot be met because some of its quorum-set members are unknown/offline and
+   are treated as non-participating). With no quorum to find, the formula is
+   *vacuously* unsatisfiable.
+
+To avoid reporting a degenerate, possibly-halted network as "safe", the analyzer
+runs a quorum-existence pre-pass before the SAT solve. It computes the **maximal
+quorum** — the union of all quorums — by a greatest-fixpoint contraction: begin
+with every validator, then repeatedly drop any validator whose quorum set is not
+satisfied by the validators that remain, until the set is stable. Because
+quorums are closed under union, the maximal quorum is empty iff the FBAS has no
+quorum at all.
+
+- Maximal quorum **empty** → `SolveStatus::NoQuorum` (degenerate / possible
+  halt); the SAT solve is skipped.
+- Maximal quorum **non-empty** → run the disjoint-quorum solve as above, giving
+  `SAT` (a split) or `UNSAT` (intertwined).
+
+This mirrors stellar-core's legacy C++ quorum-intersection checker, which detects
+the same "no quorums found" condition via its own maximal-quorum contraction and
+warns about a possible network halt.

--- a/docs/method.md
+++ b/docs/method.md
@@ -148,6 +148,7 @@ quorum at all.
 - Maximal quorum **non-empty** → run the disjoint-quorum solve as above, giving
   `SAT` (a split) or `UNSAT` (intertwined).
 
-This mirrors stellar-core's legacy C++ quorum-intersection checker, which detects
-the same "no quorums found" condition via its own maximal-quorum contraction and
-warns about a possible network halt.
+This mirrors stellar-core's legacy C++ quorum-intersection checker, which
+detects the same "no quorums found" condition via the same greatest-fixpoint
+contraction (`QuorumIntersectionCheckerImpl::contractToMaximalQuorum`) and warns
+about a possible network halt.

--- a/src/fbas.rs
+++ b/src/fbas.rs
@@ -137,6 +137,11 @@ impl Fbas {
     /// validators that belong to *some* quorum. It is empty **if and only if**
     /// the FBAS contains no quorum at all (a degenerate / potential-halt
     /// condition).
+    ///
+    /// NB: this is the same greatest-fixpoint contraction as stellar-core's
+    /// `QuorumIntersectionCheckerImpl::contractToMaximalQuorum` which computes
+    /// the greatest fixpoint of `f(X) = { n in X | X satisfies n's quorum set
+    ///  }`.
     pub(crate) fn maximal_quorum(
         &self,
         resource_limiter: &ResourceLimiter,

--- a/src/fbas.rs
+++ b/src/fbas.rs
@@ -177,8 +177,7 @@ impl Fbas {
         match self.graph.neighbors(v).next() {
             Some(qset_node) => self.node_satisfied_by(qset_node, set),
             // `from_quorum_set_map` adds exactly one edge from every validator
-            // to its quorum-set node, and validators with an empty quorum set
-            // are dropped at parse time. A `None` here therefore means the
+            // to its quorum-set node. A `None` here therefore means that
             // construction invariant was violated.
             None => Err(FbasError::InternalError(
                 "validator vertex has no quorum-set successor",
@@ -209,6 +208,9 @@ impl Fbas {
             Some(Vertex::QSet(qset)) => {
                 let mut satisfied: u32 = 0;
                 for succ in self.graph.neighbors(n) {
+                    if satisfied >= qset.threshold {
+                        return Ok(true);
+                    }
                     if self.node_satisfied_by(succ, set)? {
                         satisfied += 1;
                     }

--- a/src/fbas.rs
+++ b/src/fbas.rs
@@ -128,6 +128,98 @@ impl Fbas {
         }
     }
 
+    /// Computes the maximal quorum (the union of all quorums) as a set of
+    /// validator node indices, via a greatest-fixpoint contraction: start with
+    /// all validators and repeatedly drop any validator whose quorum set is not
+    /// satisfied by the survivors, until the set is stable.
+    ///
+    /// Because quorums are closed under union, the result is exactly the set of
+    /// validators that belong to *some* quorum. It is empty **if and only if**
+    /// the FBAS contains no quorum at all (a degenerate / potential-halt
+    /// condition).
+    pub(crate) fn maximal_quorum(
+        &self,
+        resource_limiter: &ResourceLimiter,
+    ) -> Result<BTreeSet<NodeIndex>, FbasError> {
+        let mut current: BTreeSet<NodeIndex> = self.validators.iter().copied().collect();
+        loop {
+            resource_limiter.measure_and_enforce_limits()?;
+            let mut next = BTreeSet::new();
+            for &v in &current {
+                if self.validator_satisfied_by(v, &current)? {
+                    next.insert(v);
+                }
+            }
+            // `next` is always a subset of `current`, so equal sizes means we
+            // reached the fixpoint.
+            if next.len() == current.len() {
+                return Ok(next);
+            }
+            current = next;
+        }
+    }
+
+    /// A validator is satisfied by `set` iff its single quorum-set successor is
+    /// satisfied by `set`.
+    ///
+    /// Returns `Err(InternalError)` if the validator has no quorum-set
+    /// successor. This is unreachable in a well-formed graph.
+    fn validator_satisfied_by(
+        &self,
+        v: NodeIndex,
+        set: &BTreeSet<NodeIndex>,
+    ) -> Result<bool, FbasError> {
+        match self.graph.neighbors(v).next() {
+            Some(qset_node) => self.node_satisfied_by(qset_node, set),
+            // `from_quorum_set_map` adds exactly one edge from every validator
+            // to its quorum-set node, and validators with an empty quorum set
+            // are dropped at parse time. A `None` here therefore means the
+            // construction invariant was violated.
+            None => Err(FbasError::InternalError(
+                "validator vertex has no quorum-set successor",
+            )),
+        }
+    }
+
+    /// Whether a graph node is satisfied by `set`:
+    /// - a validator node is satisfied iff it is a member of `set`;
+    /// - a quorum-set node is satisfied iff at least `threshold` of its
+    ///   successors are satisfied (recursing through inner quorum-set nodes).
+    ///
+    /// Recursion descends only into quorum-set successors (validator successors
+    /// are base cases) and the quorum-set subgraph is acyclic, so this always
+    /// terminates. A threshold of 0 is trivially satisfied; a threshold greater
+    /// than the number of satisfiable successors is never satisfied — matching
+    /// the SAT encoding's treatment of these cases.
+    ///
+    /// Returns `Err(InternalError)` if `n` does not resolve to a vertex. This is
+    /// unreachable in a well-formed graph.
+    fn node_satisfied_by(
+        &self,
+        n: NodeIndex,
+        set: &BTreeSet<NodeIndex>,
+    ) -> Result<bool, FbasError> {
+        match self.graph.node_weight(n) {
+            Some(Vertex::Validator(_)) => Ok(set.contains(&n)),
+            Some(Vertex::QSet(qset)) => {
+                let mut satisfied: u32 = 0;
+                for succ in self.graph.neighbors(n) {
+                    if self.node_satisfied_by(succ, set)? {
+                        satisfied += 1;
+                    }
+                }
+                Ok(satisfied >= qset.threshold)
+            }
+            // `n` is only ever obtained from `graph.neighbors(...)` or the
+            // validator->qset edge, both of which yield valid, existing node
+            // indices. A `None` here therefore means the graph is internally
+            // inconsistent.
+            None => Err(FbasError::InternalError(
+                "graph node index has no vertex weight",
+            )),
+        }
+    }
+
     fn from_quorum_set_map(
         qsm: QuorumSetMap,
         resource_limiter: &ResourceLimiter,

--- a/src/fbas_analyze.rs
+++ b/src/fbas_analyze.rs
@@ -82,6 +82,12 @@ pub struct FbasAnalyzer {
 pub enum SolveStatus {
     UNSAT,
     SAT((Vec<NodeIndex>, Vec<NodeIndex>)),
+    /// The FBAS contains no quorum at all (e.g. a validator depends on nodes
+    /// that cannot satisfy its threshold). The disjoint-quorum question is
+    /// vacuously unsatisfiable here, but this is a degenerate / potential-halt
+    /// condition and must NOT be conflated with `UNSAT` ("a quorum exists and
+    /// all quorums intersect").
+    NoQuorum,
     #[default]
     UNKNOWN,
 }
@@ -93,6 +99,7 @@ impl std::fmt::Debug for SolveStatus {
             SolveStatus::SAT((quorum_a, quorum_b)) => {
                 write!(f, "SAT(quorum_a: {quorum_a:?}, quorum_b: {quorum_b:?})")
             }
+            SolveStatus::NoQuorum => write!(f, "NoQuorum"),
             SolveStatus::UNKNOWN => write!(f, "UNKNOWN"),
         }
     }
@@ -269,13 +276,29 @@ impl FbasAnalyzer {
     }
 
     pub fn solve(&mut self) -> Result<SolveStatus, FbasError> {
+        let resource_limiter = self.solver.cb().clone();
+
+        // Quorum-existence pre-pass: if the FBAS has no quorum at all, the
+        // disjoint-quorum formula is vacuously unsatisfiable. Report this as a
+        // distinct `NoQuorum` (degenerate / possible network halt) rather than
+        // conflating it with `UNSAT` ("a quorum exists and all quorums
+        // intersect"), and skip the SAT solve.
+        if self.fbas.maximal_quorum(&resource_limiter)?.is_empty() {
+            warn!(
+                target: "SCP",
+                "FbasAnalyzer found no quorum in the FBAS (possible network halt)"
+            );
+            self.status = SolveStatus::NoQuorum;
+            resource_limiter.measure_and_enforce_limits()?;
+            return Ok(self.status.clone());
+        }
+
         let mut th = theory::EmptyTheory::new();
         // Note on resource limiting: the solver checks `ResourceLimiter::stop()` internally
         // on its inner loop. If resource limits are exceeds, it will discontinue and return
         // `SolveStatus::UNKNOWN`.
         // In order for the solver to return a `ResourcelimitExceeded` error, we need to
         // enforce the limit before returning.
-        let resource_limiter = self.solver.cb().clone();
         let result = self.solver.solve_limited_th_full(&mut th, &[]);
         self.status = match result {
             SolveResult::Sat(model) => {

--- a/src/fbas_analyze.rs
+++ b/src/fbas_analyze.rs
@@ -134,14 +134,22 @@ impl FbasAnalyzer {
         fbas: Fbas,
         resource_limiter: ResourceLimiter,
     ) -> Result<Self, FbasError> {
+        let status = if fbas.maximal_quorum(&resource_limiter)?.is_empty() {
+            SolveStatus::NoQuorum
+        } else {
+            SolveStatus::UNKNOWN
+        };
+
         let mut analyzer = Self {
             fbas,
             solver: Solver::new(Default::default(), resource_limiter),
-            status: SolveStatus::UNKNOWN,
+            status,
             vars: VarManager::default(),
         };
-        analyzer.construct_vars()?;
-        analyzer.construct_formula()?;
+        if analyzer.status != SolveStatus::NoQuorum {
+            analyzer.construct_vars()?;
+            analyzer.construct_formula()?;
+        }
         Ok(analyzer)
     }
 
@@ -278,17 +286,11 @@ impl FbasAnalyzer {
     pub fn solve(&mut self) -> Result<SolveStatus, FbasError> {
         let resource_limiter = self.solver.cb().clone();
 
-        // Quorum-existence pre-pass: if the FBAS has no quorum at all, the
-        // disjoint-quorum formula is vacuously unsatisfiable. Report this as a
-        // distinct `NoQuorum` (degenerate / possible network halt) rather than
-        // conflating it with `UNSAT` ("a quorum exists and all quorums
-        // intersect"), and skip the SAT solve.
-        if self.fbas.maximal_quorum(&resource_limiter)?.is_empty() {
+        if self.status == SolveStatus::NoQuorum {
             warn!(
                 target: "SCP",
                 "FbasAnalyzer found no quorum in the FBAS (possible network halt)"
             );
-            self.status = SolveStatus::NoQuorum;
             resource_limiter.measure_and_enforce_limits()?;
             return Ok(self.status.clone());
         }
@@ -350,5 +352,14 @@ impl FbasAnalyzer {
             }
             _ => Ok((vec![], vec![])),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn sat_formula_size_for_test(&self) -> (usize, u64, usize) {
+        (
+            self.solver.num_vars() as usize,
+            self.solver.num_clauses(),
+            self.vars.node_quorum_membership.len(),
+        )
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,6 @@
 mod allocator;
 mod analyze;
 mod limits;
+mod no_quorum;
 #[cfg(any(feature = "json", test))]
 mod parse;

--- a/src/test/no_quorum.rs
+++ b/src/test/no_quorum.rs
@@ -73,6 +73,17 @@ fn solve_reports_no_quorum_when_threshold_exceeds_degree() {
 }
 
 #[test]
+fn no_quorum_analyzer_skips_sat_formula_construction() {
+    let analyzer = FbasAnalyzer::from_json_path(
+        &format!("{DATA_DIR}no_quorum_threshold_exceeds_degree.json"),
+        ResourceLimiter::unlimited(),
+    )
+    .expect("load analyzer");
+
+    assert_eq!(analyzer.sat_formula_size_for_test(), (0, 0, 0));
+}
+
+#[test]
 fn solve_reports_split_when_feasible() {
     let status = solve_status(&format!("{DATA_DIR}feasible_split_with_unknown.json"));
     assert!(

--- a/src/test/no_quorum.rs
+++ b/src/test/no_quorum.rs
@@ -1,0 +1,91 @@
+use crate::fbas::Fbas;
+use crate::{FbasAnalyzer, ResourceLimiter, SolveStatus};
+use std::collections::BTreeSet;
+
+const DATA_DIR: &str = "./tests/test_data/no_quorum/";
+
+#[test]
+fn no_quorum_status_formats_and_differs_from_unsat() {
+    let status = SolveStatus::NoQuorum;
+    assert_eq!(format!("{status:?}"), "NoQuorum");
+    assert_ne!(status, SolveStatus::UNSAT);
+}
+
+fn maximal_quorum_strings(path: &str) -> BTreeSet<String> {
+    let rl = ResourceLimiter::unlimited();
+    let fbas = Fbas::from_json_path(path, &rl).expect("load fbas");
+    fbas.maximal_quorum(&rl)
+        .expect("maximal quorum")
+        .iter()
+        .map(|ni| fbas.try_get_validator_string(ni).expect("validator string"))
+        .collect()
+}
+
+#[test]
+fn maximal_quorum_intertwined_is_all_validators() {
+    let mq = maximal_quorum_strings(&format!("{DATA_DIR}intertwined.json"));
+    assert_eq!(
+        mq,
+        BTreeSet::from(["A".to_string(), "B".to_string(), "C".to_string()])
+    );
+}
+
+#[test]
+fn maximal_quorum_empty_when_threshold_exceeds_degree() {
+    let rl = ResourceLimiter::unlimited();
+    let fbas = Fbas::from_json_path(
+        &format!("{DATA_DIR}no_quorum_threshold_exceeds_degree.json"),
+        &rl,
+    )
+    .expect("load fbas");
+    assert!(fbas.maximal_quorum(&rl).expect("maximal quorum").is_empty());
+}
+
+#[test]
+fn maximal_quorum_feasible_with_unknown_is_all_validators() {
+    let mq = maximal_quorum_strings(&format!("{DATA_DIR}feasible_split_with_unknown.json"));
+    assert_eq!(
+        mq,
+        BTreeSet::from([
+            "A".to_string(),
+            "B".to_string(),
+            "C".to_string(),
+            "D".to_string(),
+        ])
+    );
+}
+
+fn solve_status(path: &str) -> SolveStatus {
+    let mut analyzer =
+        FbasAnalyzer::from_json_path(path, ResourceLimiter::unlimited()).expect("load analyzer");
+    analyzer.solve().expect("solve")
+}
+
+#[test]
+fn solve_reports_no_quorum_when_threshold_exceeds_degree() {
+    let status = solve_status(&format!(
+        "{DATA_DIR}no_quorum_threshold_exceeds_degree.json"
+    ));
+    assert!(
+        matches!(status, SolveStatus::NoQuorum),
+        "expected NoQuorum, got {status}"
+    );
+}
+
+#[test]
+fn solve_reports_split_when_feasible() {
+    let status = solve_status(&format!("{DATA_DIR}feasible_split_with_unknown.json"));
+    assert!(
+        matches!(status, SolveStatus::SAT(_)),
+        "expected SAT (split), got {status}"
+    );
+}
+
+#[test]
+fn solve_reports_unsat_when_intertwined() {
+    let status = solve_status(&format!("{DATA_DIR}intertwined.json"));
+    assert!(
+        matches!(status, SolveStatus::UNSAT),
+        "expected UNSAT (intertwined), got {status}"
+    );
+}

--- a/tests/test_data/no_quorum/feasible_split_with_unknown.json
+++ b/tests/test_data/no_quorum/feasible_split_with_unknown.json
@@ -1,0 +1,6 @@
+[
+  {"publicKey":"A","quorumSet":{"threshold":2,"validators":["A","B","GHOST"],"innerQuorumSets":[]}},
+  {"publicKey":"B","quorumSet":{"threshold":2,"validators":["A","B","GHOST"],"innerQuorumSets":[]}},
+  {"publicKey":"C","quorumSet":{"threshold":2,"validators":["C","D","GHOST"],"innerQuorumSets":[]}},
+  {"publicKey":"D","quorumSet":{"threshold":2,"validators":["C","D","GHOST"],"innerQuorumSets":[]}}
+]

--- a/tests/test_data/no_quorum/intertwined.json
+++ b/tests/test_data/no_quorum/intertwined.json
@@ -1,0 +1,5 @@
+[
+  {"publicKey":"A","quorumSet":{"threshold":2,"validators":["A","B","C"],"innerQuorumSets":[]}},
+  {"publicKey":"B","quorumSet":{"threshold":2,"validators":["A","B","C"],"innerQuorumSets":[]}},
+  {"publicKey":"C","quorumSet":{"threshold":2,"validators":["A","B","C"],"innerQuorumSets":[]}}
+]

--- a/tests/test_data/no_quorum/no_quorum_threshold_exceeds_degree.json
+++ b/tests/test_data/no_quorum/no_quorum_threshold_exceeds_degree.json
@@ -1,0 +1,6 @@
+[
+  {"publicKey":"A","quorumSet":{"threshold":3,"validators":["A","B","GHOST"],"innerQuorumSets":[]}},
+  {"publicKey":"B","quorumSet":{"threshold":3,"validators":["A","B","GHOST"],"innerQuorumSets":[]}},
+  {"publicKey":"C","quorumSet":{"threshold":3,"validators":["C","D","GHOST"],"innerQuorumSets":[]}},
+  {"publicKey":"D","quorumSet":{"threshold":3,"validators":["C","D","GHOST"],"innerQuorumSets":[]}}
+]


### PR DESCRIPTION
### What

Add a quorum-existence pre-pass before the SAT solve. It computes the maximal quorum (the union of all quorums) by a greatest-fixpoint contraction: start with all validators, repeatedly drop any whose quorum set isn't satisfied by the survivors, until stable.
  - Empty → log a "possible network halt" warning and return the new `SolveStatus::NoQuorum`, skipping the solve.
  - Non-empty → run the existing disjoint-quorum solve unchanged.

The change is purely additive: every prior `SAT`/`UNSAT` verdict is unchanged; 

### Why

Previously `UNSAT` means either "no disjoint quorums / safe" or no quorum at all (e.g. all validators have thresholds that can't be met, so a network that can't form a quorum was distinguishable to a healthy intertwined one. `UNSAT` now strictly means "a quorum exists and all quorums intersect." This matches stellar-core's legacy C++ checker, which detects the same condition via its own maximal-quorum contraction and warns about a possible halt.