### PR TITLE
Point stellar-xdr at the ungated rev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "crate-git-revision"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54851b5b3f24621804b1cded2820975623c205e3055d2d44031cdb1237339ac8"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,17 +562,16 @@ version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.6",
  "data-encoding",
 ]
 
 [[package]]
 name = "stellar-xdr"
 version = "27.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ff843326969bdf1ef673dcdba94c08f4a3c8f1e58d6e6ef39b1bd4f749179a"
+source = "git+https://github.com/stellar/rs-stellar-xdr?rev=3305b3e31f19fdb4e64e4b7a4354bb120cdf4415#3305b3e31f19fdb4e64e4b7a4354bb120cdf4415"
 dependencies = [
- "crate-git-revision",
+ "crate-git-revision 0.0.9",
  "escape-bytes",
  "ethnum",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0"
 
 [dependencies]
 petgraph = "=0.6.5"
-stellar-xdr = "=27.0.0"
+stellar-xdr = { version = "=27.0.0", git = "https://github.com/stellar/rs-stellar-xdr", rev = "3305b3e31f19fdb4e64e4b7a4354bb120cdf4415" }
 json = { version = "0.12.4", optional = true }
 itertools = "0.10.5"
 stellar-strkey = "0.0.13"

--- a/src/fbas.rs
+++ b/src/fbas.rs
@@ -262,7 +262,7 @@ impl Fbas {
         let mut known_qsets = BTreeMap::new();
 
         // First pass: add all validators
-        for (node_str, _) in qsm.iter() {
+        for node_str in qsm.keys() {
             let idx = fbas.add_validator(node_str.clone());
             known_validators.insert(node_str, idx);
         }


### PR DESCRIPTION
stellar-core's `checkXDRFileIdentity` compares this crate's `XDR_FILES_SHA256` against the current soroban host's. Core is bumping to protocol 28 (stellar/stellar-core#5397), whose host pins `stellar-xdr` by git rev, so the published 27.0.0 crate no longer matches — `Stellar-contract.x` hashes `5d8063e6` here vs `b87e9474` there — and core aborts at startup.

Pins the same git rev (stellar/rs-stellar-xdr#565, where CAP-0083 and CAP-0085 were ungated) so the hashes agree. Reverts to a plain version pin once rs-stellar-xdr publishes a release carrying those changes.

Second commit is unrelated: `clippy::for_kv_map` at `src/fbas.rs:265` has failed on main since 2026-07-09 (it only fires on the newer clippy CI uses). Fixed here so this PR can go green.